### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -36,7 +36,7 @@ jobs:
       if: steps.cache-ndk.outputs.cache-hit != 'true'
       run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;21.0.6113669" --sdk_root=${ANDROID_SDK_ROOT}
     - id: vars
-      run: echo ::set-output name=tag::${GITHUB_REF:10}
+      run: echo tag=${GITHUB_REF:10} >> $GITHUB_OUTPUT
     - uses: subosito/flutter-action@v1
       with:
         flutter-version: '2.8.x'

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -36,7 +36,7 @@ jobs:
       if: steps.cache-ndk.outputs.cache-hit != 'true'
       run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;21.0.6113669" --sdk_root=${ANDROID_SDK_ROOT}
     - id: vars
-      run: echo tag=${GITHUB_REF:10} >> $GITHUB_OUTPUT
+      run: echo tag=${GITHUB_REF:10} >> "$GITHUB_OUTPUT"
     - uses: subosito/flutter-action@v1
       with:
         flutter-version: '2.8.x'


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


